### PR TITLE
Disabled quote keys (postgres 9.3.4 compatible)

### DIFF
--- a/tosql.py
+++ b/tosql.py
@@ -221,7 +221,7 @@ def build_select_query(name, param_dict):
 	return select_query
 
 
-def build_insert_query(name, param_dict, quote_keys = True):
+def build_insert_query(name, param_dict, quote_keys = False):
 	global Database
 	if not param_dict:
 		print "build_insert_query: [error] param dictionary is empty!"


### PR DESCRIPTION
Thanks for the awesome code!

There's one issue with postgres though - when you quote your keys it's not recognised as a valid query:
imdb_data=# insert into actors (`lname`, `fname`, `idactors`) values ("a", "b", 3);
ERROR:  syntax error at or near "`"
LINE 1: insert into actors (`lname`, `fname`, `idactors`) values ("a...
                            ^
I'm not sure if postgres ever supported that (http://www.postgresql.org/docs/7.1/static/sql-insert.html doesn't mention the backquotes anywhere). Any other RDBMS I know doesn't need those as well.

I think it's safe to just not include the quote keys by default.
