### PR TITLE
removing ALTER TABLE who forces postgres be the owner

### DIFF
--- a/schemas/postgres.sql
+++ b/schemas/postgres.sql
@@ -25,7 +25,6 @@ CREATE TABLE acted_in (
 );
 
 
-ALTER TABLE public.acted_in OWNER TO postgres;
 
 --
 -- Name: acted_in_idacted_in_seq; Type: SEQUENCE; Schema: public; Owner: postgres
@@ -39,7 +38,6 @@ CREATE SEQUENCE acted_in_idacted_in_seq
     CACHE 1;
 
 
-ALTER TABLE public.acted_in_idacted_in_seq OWNER TO postgres;
 
 --
 -- Name: acted_in_idacted_in_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
@@ -62,7 +60,6 @@ CREATE TABLE actors (
 );
 
 
-ALTER TABLE public.actors OWNER TO postgres;
 
 --
 -- Name: actors_idactors_seq; Type: SEQUENCE; Schema: public; Owner: postgres
@@ -76,7 +73,6 @@ CREATE SEQUENCE actors_idactors_seq
     CACHE 1;
 
 
-ALTER TABLE public.actors_idactors_seq OWNER TO postgres;
 
 --
 -- Name: actors_idactors_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
@@ -96,7 +92,6 @@ CREATE TABLE aka_names (
 );
 
 
-ALTER TABLE public.aka_names OWNER TO postgres;
 
 --
 -- Name: aka_names_idaka_names_seq; Type: SEQUENCE; Schema: public; Owner: postgres
@@ -110,7 +105,6 @@ CREATE SEQUENCE aka_names_idaka_names_seq
     CACHE 1;
 
 
-ALTER TABLE public.aka_names_idaka_names_seq OWNER TO postgres;
 
 --
 -- Name: aka_names_idaka_names_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
@@ -132,7 +126,6 @@ CREATE TABLE aka_titles (
 );
 
 
-ALTER TABLE public.aka_titles OWNER TO postgres;
 
 --
 -- Name: aka_titles_idaka_titles_seq; Type: SEQUENCE; Schema: public; Owner: postgres
@@ -146,7 +139,6 @@ CREATE SEQUENCE aka_titles_idaka_titles_seq
     CACHE 1;
 
 
-ALTER TABLE public.aka_titles_idaka_titles_seq OWNER TO postgres;
 
 --
 -- Name: aka_titles_idaka_titles_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
@@ -165,7 +157,6 @@ CREATE TABLE genres (
 );
 
 
-ALTER TABLE public.genres OWNER TO postgres;
 
 --
 -- Name: genres_idgenres_seq; Type: SEQUENCE; Schema: public; Owner: postgres
@@ -179,7 +170,6 @@ CREATE SEQUENCE genres_idgenres_seq
     CACHE 1;
 
 
-ALTER TABLE public.genres_idgenres_seq OWNER TO postgres;
 
 --
 -- Name: genres_idgenres_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
@@ -198,7 +188,6 @@ CREATE TABLE keywords (
 );
 
 
-ALTER TABLE public.keywords OWNER TO postgres;
 
 --
 -- Name: keywords_idkeywords_seq; Type: SEQUENCE; Schema: public; Owner: postgres
@@ -212,7 +201,6 @@ CREATE SEQUENCE keywords_idkeywords_seq
     CACHE 1;
 
 
-ALTER TABLE public.keywords_idkeywords_seq OWNER TO postgres;
 
 --
 -- Name: keywords_idkeywords_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
@@ -236,7 +224,6 @@ CREATE TABLE movies (
 );
 
 
-ALTER TABLE public.movies OWNER TO postgres;
 
 --
 -- Name: movies_genres; Type: TABLE; Schema: public; Owner: postgres; Tablespace: 
@@ -250,7 +237,6 @@ CREATE TABLE movies_genres (
 );
 
 
-ALTER TABLE public.movies_genres OWNER TO postgres;
 
 --
 -- Name: movies_genres_idmovies_genres_seq; Type: SEQUENCE; Schema: public; Owner: postgres
@@ -264,7 +250,6 @@ CREATE SEQUENCE movies_genres_idmovies_genres_seq
     CACHE 1;
 
 
-ALTER TABLE public.movies_genres_idmovies_genres_seq OWNER TO postgres;
 
 --
 -- Name: movies_genres_idmovies_genres_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
@@ -285,7 +270,6 @@ CREATE SEQUENCE movies_idmovies_seq
     CACHE 1;
 
 
-ALTER TABLE public.movies_idmovies_seq OWNER TO postgres;
 
 --
 -- Name: movies_idmovies_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
@@ -306,7 +290,6 @@ CREATE TABLE movies_keywords (
 );
 
 
-ALTER TABLE public.movies_keywords OWNER TO postgres;
 
 --
 -- Name: movies_keywords_idmovies_keywords_seq; Type: SEQUENCE; Schema: public; Owner: postgres
@@ -320,7 +303,6 @@ CREATE SEQUENCE movies_keywords_idmovies_keywords_seq
     CACHE 1;
 
 
-ALTER TABLE public.movies_keywords_idmovies_keywords_seq OWNER TO postgres;
 
 --
 -- Name: movies_keywords_idmovies_keywords_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
@@ -342,7 +324,6 @@ CREATE TABLE series (
 );
 
 
-ALTER TABLE public.series OWNER TO postgres;
 
 --
 -- Name: series_id_series_seq; Type: SEQUENCE; Schema: public; Owner: postgres
@@ -356,7 +337,6 @@ CREATE SEQUENCE series_id_series_seq
     CACHE 1;
 
 
-ALTER TABLE public.series_id_series_seq OWNER TO postgres;
 
 --
 -- Name: series_id_series_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
@@ -523,4 +503,3 @@ REVOKE ALL ON SCHEMA public FROM PUBLIC;
 REVOKE ALL ON SCHEMA public FROM postgres;
 GRANT ALL ON SCHEMA public TO postgres;
 GRANT ALL ON SCHEMA public TO PUBLIC;
-

--- a/schemas/postgres.use_dict.sql
+++ b/schemas/postgres.use_dict.sql
@@ -25,7 +25,6 @@ CREATE TABLE acted_in (
 );
 
 
-ALTER TABLE public.acted_in OWNER TO postgres;
 
 --
 -- Name: acted_in_idacted_in_seq; Type: SEQUENCE; Schema: public; Owner: postgres
@@ -39,7 +38,6 @@ CREATE SEQUENCE acted_in_idacted_in_seq
     CACHE 1;
 
 
-ALTER TABLE public.acted_in_idacted_in_seq OWNER TO postgres;
 
 --
 -- Name: acted_in_idacted_in_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
@@ -62,7 +60,6 @@ CREATE TABLE actors (
 );
 
 
-ALTER TABLE public.actors OWNER TO postgres;
 
 --
 -- Name: aka_names; Type: TABLE; Schema: public; Owner: postgres; Tablespace: 
@@ -75,7 +72,6 @@ CREATE TABLE aka_names (
 );
 
 
-ALTER TABLE public.aka_names OWNER TO postgres;
 
 --
 -- Name: aka_names_idaka_names_seq; Type: SEQUENCE; Schema: public; Owner: postgres
@@ -89,7 +85,6 @@ CREATE SEQUENCE aka_names_idaka_names_seq
     CACHE 1;
 
 
-ALTER TABLE public.aka_names_idaka_names_seq OWNER TO postgres;
 
 --
 -- Name: aka_names_idaka_names_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
@@ -108,7 +103,6 @@ CREATE TABLE genres (
 );
 
 
-ALTER TABLE public.genres OWNER TO postgres;
 
 --
 -- Name: idaka_titles; Type: TABLE; Schema: public; Owner: postgres; Tablespace: 
@@ -123,7 +117,6 @@ CREATE TABLE aka_titles (
 );
 
 
-ALTER TABLE public.aka_titles OWNER TO postgres;
 
 --
 -- Name: idaka_titles_idaka_titles_seq; Type: SEQUENCE; Schema: public; Owner: postgres
@@ -137,7 +130,6 @@ CREATE SEQUENCE aka_titles_idaka_titles_seq
     CACHE 1;
 
 
-ALTER TABLE public.aka_titles_idaka_titles_seq OWNER TO postgres;
 
 --
 -- Name: idaka_titles_idaka_titles_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
@@ -156,7 +148,6 @@ CREATE TABLE keywords (
 );
 
 
-ALTER TABLE public.keywords OWNER TO postgres;
 
 --
 -- Name: movies; Type: TABLE; Schema: public; Owner: postgres; Tablespace: 
@@ -173,7 +164,6 @@ CREATE TABLE movies (
 );
 
 
-ALTER TABLE public.movies OWNER TO postgres;
 
 --
 -- Name: movies_genres; Type: TABLE; Schema: public; Owner: postgres; Tablespace: 
@@ -187,7 +177,6 @@ CREATE TABLE movies_genres (
 );
 
 
-ALTER TABLE public.movies_genres OWNER TO postgres;
 
 --
 -- Name: movies_genres_idmovies_genres_seq; Type: SEQUENCE; Schema: public; Owner: postgres
@@ -201,7 +190,6 @@ CREATE SEQUENCE movies_genres_idmovies_genres_seq
     CACHE 1;
 
 
-ALTER TABLE public.movies_genres_idmovies_genres_seq OWNER TO postgres;
 
 --
 -- Name: movies_genres_idmovies_genres_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
@@ -222,7 +210,6 @@ CREATE TABLE movies_keywords (
 );
 
 
-ALTER TABLE public.movies_keywords OWNER TO postgres;
 
 --
 -- Name: movies_keywords_idmovies_keywords_seq; Type: SEQUENCE; Schema: public; Owner: postgres
@@ -236,7 +223,6 @@ CREATE SEQUENCE movies_keywords_idmovies_keywords_seq
     CACHE 1;
 
 
-ALTER TABLE public.movies_keywords_idmovies_keywords_seq OWNER TO postgres;
 
 --
 -- Name: movies_keywords_idmovies_keywords_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
@@ -258,7 +244,6 @@ CREATE TABLE series (
 );
 
 
-ALTER TABLE public.series OWNER TO postgres;
 
 --
 -- Name: idacted_in; Type: DEFAULT; Schema: public; Owner: postgres
@@ -383,4 +368,3 @@ REVOKE ALL ON SCHEMA public FROM PUBLIC;
 REVOKE ALL ON SCHEMA public FROM postgres;
 GRANT ALL ON SCHEMA public TO postgres;
 GRANT ALL ON SCHEMA public TO PUBLIC;
-


### PR DESCRIPTION
Hi There,

the files `schemas/postgres.sql` and `schemas/postgres.use_dict.sql` are ignoring the setting `Database.user` when assigning the table owner.

I think this is a standard output from pg_dump then I removed all `ALTER TABLES xxxx OWNER TO postgres;` from both files.

By default, the current logged user is the owner of the new object. 

Sorry for my poor english.

Thanks!
